### PR TITLE
Load environment variables in passport config

### DIFF
--- a/backend/src/config/passport.js
+++ b/backend/src/config/passport.js
@@ -1,6 +1,12 @@
+import dotenv from 'dotenv';
 import passport from 'passport';
 import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
 import User from '../models/User.js';
+
+dotenv.config();
+const currentEnv = process.env.NODE_ENV || 'development';
+dotenv.config({ path: `.env.${currentEnv}`, override: true });
+
 
 passport.use(
     new GoogleStrategy(


### PR DESCRIPTION
Import and initialize dotenv in passport.js, loading the base .env and then an environment-specific .env.{NODE_ENV} (defaulting to development) with override. This ensures environment variables (e.g. Google OAuth credentials) are available when configuring the GoogleStrategy and allows env-specific overrides.