### PR TITLE
Handle errors in Google OAuth callback

### DIFF
--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -12,18 +12,23 @@ router.get('/google', passport.authenticate('google', { scope: ['profile', 'emai
 router.get('/google/callback',
     passport.authenticate('google', { session: false, failureRedirect: `${process.env.FRONTEND_URL}/login` }),
     async (req, res) => {
-        const accessToken = generateAccessToken(req.user._id);
-        const refreshToken = generateRefreshToken(req.user._id);
+        try {
+            const accessToken = generateAccessToken(req.user._id);
+            const refreshToken = generateRefreshToken(req.user._id);
 
-        //create a new refresh token in the database
-        await RefreshToken.create({
-            userId: req.user._id,
-            token: refreshToken,
-            expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
-        });
+            //create a new refresh token in the database
+            await RefreshToken.create({
+                userId: req.user._id,
+                token: refreshToken,
+                expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+            });
 
-        // Redirect to frontend with tokens in URL
-        res.redirect(`${process.env.FRONTEND_URL}/oauth-callback?accessToken=${accessToken}&refreshToken=${refreshToken}`);
+            // Redirect to frontend with tokens in URL
+            res.redirect(`${process.env.FRONTEND_URL}/oauth-callback?accessToken=${accessToken}&refreshToken=${refreshToken}`);
+        } catch (error) {
+            console.error('OAuth callback error:', error);
+            res.redirect(`${process.env.FRONTEND_URL}/login?error=oauth_failed`);
+        }
     }
 );
 


### PR DESCRIPTION
Wrap token generation, refresh-token persistence, and redirect logic in a try/catch in the Google OAuth callback route. On error the code now logs the issue and redirects the user to FRONTEND_URL/login?error=oauth_failed to avoid uncaught exceptions during the OAuth flow.