### PR TITLE
Make lastName optional for Google users

### DIFF
--- a/backend/src/config/passport.js
+++ b/backend/src/config/passport.js
@@ -39,7 +39,7 @@ passport.use(
                 user = await User.create({
                     googleId: profile.id,
                     firstName: profile.name?.givenName || 'User',
-                    lastName: profile.name?.familyName || '',
+                    lastName: profile.name?.familyName || undefined,
                     email: email || '',
                     phoneNumber: '',
                     location: '',

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -12,7 +12,7 @@ const userSchema = new mongoose.Schema({
     },
     lastName: {
         type: String,
-        required: [true, "Second name is required!"],
+        required: function() { return !this.googleId; },
         trim: true,
         minlength: [2, 'Last name must be at least 2 characters']
     },


### PR DESCRIPTION
Allow creating users via Google OAuth when the Google profile lacks a familyName. Set lastName to undefined in passport user creation instead of an empty string, and make the User schema's lastName required validator conditional (required only if googleId is not present). This prevents validation errors for Google-authenticated users without a familyName.