### PR TITLE
Add SEO, spinner tweaks & profile init flag

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,6 +11,18 @@
 <link rel="icon" type="image/svg+xml" href="/assets/favicons/favicon.svg" />
 <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicons/apple-touch-icon.png" />
 <link rel="manifest" href="/assets/favicons/site.webmanifest" />
+  <meta name="description" content="Discover your next career move with our job board. Browse thousands of job listings and find the perfect fit." />
+  <meta property="og:title" content="Job Board - Find Your Next Opportunity" />
+  <meta property="og:description" content="Discover your next career move with our job board. Browse thousands of job listings and find the perfect fit." />
+  <meta property="og:image" content="https://job-board-three-omega.vercel.app/og-default.svg" />
+  <meta property="og:url" content="https://job-board-three-omega.vercel.app/" />
+  <meta property="og:site_name" content="Job Board" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Job Board - Find Your Next Opportunity" />
+  <meta name="twitter:description" content="Discover your next career move with our job board. Browse thousands of job listings and find the perfect fit." />
+  <meta name="twitter:image" content="https://job-board-three-omega.vercel.app/og-default.svg" />
+  <link rel="canonical" href="https://job-board-three-omega.vercel.app/" />
     <title>Job Board - Find Your Next Opportunity</title>
   </head>
   <body>

--- a/frontend/src/components/Company/SendMessage/SendMessage.tsx
+++ b/frontend/src/components/Company/SendMessage/SendMessage.tsx
@@ -1,7 +1,7 @@
 
 import useCompany from "../../../hooks/utils/useCompany";
 import { useNotification } from "../../../hooks/utils/useNotification";
-import useUserProfile from "../../../hooks/utils/useProfile";
+import useUserProfile from "../../../hooks/utils/useProfileUtils";
 import { useValidation } from "../../validators/useValidation";
 import "./SendMessage.css";
 

--- a/frontend/src/components/EditProfile/ChangePassword/ChangePassword.tsx
+++ b/frontend/src/components/EditProfile/ChangePassword/ChangePassword.tsx
@@ -3,7 +3,7 @@ import "./ChangePassword.css";
 import { useChangePasswordValidation } from "../../validators/useChangePasswordValidation";
 import { useNavigate } from "react-router";
 import { showSuccess } from "../../../utils/toast";
-import useUserProfile from "../../../hooks/utils/useProfile";
+import useUserProfile from "../../../hooks/utils/useProfileUtils";
 import useForm from "../../../hooks/shared/useForm";
 
 export interface changePasswordForm extends Record<string, string> {

--- a/frontend/src/components/EditProfile/EditProfile.tsx
+++ b/frontend/src/components/EditProfile/EditProfile.tsx
@@ -4,7 +4,7 @@ import Spinner from "../Spinner/Spinner";
 import { useNavigate } from "react-router";
 import { showSuccess } from "../../utils/toast";
 import { useValidation } from "../validators/useValidation";
-import useUserProfile from "../../hooks/utils/useProfile";
+import useUserProfile from "../../hooks/utils/useProfileUtils";
 import useForm from "../../hooks/shared/useForm";
 import { useState, useEffect } from "react";
 import { generateSeoConfig } from "../../seo/seo";

--- a/frontend/src/components/Profile/Profile.tsx
+++ b/frontend/src/components/Profile/Profile.tsx
@@ -2,7 +2,7 @@ import "./Profile.css";
 import "./Responsive.css";
 import { useEffect, useState } from "react";
 import Spinner from "../Spinner/Spinner";
-import useUserProfile from "../../hooks/utils/useProfile";
+import useUserProfile from "../../hooks/utils/useProfileUtils";
 import { useNavigate } from "react-router";
 import useCompany from "../../hooks/utils/useCompany";
 import { useRole } from "../../context/RoleContext";
@@ -22,6 +22,7 @@ interface ProfileProps {
 export default function MyProfile({ LogOutComponnent }: ProfileProps) {
   const {
     loading: userLoading,
+    isInitialized,
     userData,
     avatar,
     handleFileChange,
@@ -81,7 +82,11 @@ export default function MyProfile({ LogOutComponnent }: ProfileProps) {
 
   const seo = generateSeoConfig("profile");
 
+  const isProfilePending = userLoading || !isInitialized;
 
+  if (!userData && isProfilePending) {
+    return <Spinner overlay={true} />;
+  }
 
   if (!userData) {
     return (
@@ -122,7 +127,7 @@ export default function MyProfile({ LogOutComponnent }: ProfileProps) {
         <meta name="description" content={seoConfig.profile.description} />
       </Helmet>
 
-      {userLoading || (!!userData && !isCompanyReady) ? (
+      {userLoading || (!isInitialized && !userData) || (!!userData && !isCompanyReady) ? (
         <Spinner overlay={true} />
       ) : (
         <Container maxwith="1520px" padding="0 12px">

--- a/frontend/src/components/Spinner/Spinner.tsx
+++ b/frontend/src/components/Spinner/Spinner.tsx
@@ -16,10 +16,8 @@ export default function Spinner({ overlay = false, inline = false }: SpinnerProp
   }
 
   return (
-      <div className="profile-body" style={{ position: "relative" }}>
-        <div className="body-spinner">
-          <div className="spinner-body"></div> 
-        </div>
+    <div className="body-spinner" role="status" aria-label="Loading">
+      <div className="spinner-body"></div>
     </div>
-      );
+  );
 }

--- a/frontend/src/components/Spinner/bodySpinner.css
+++ b/frontend/src/components/Spinner/bodySpinner.css
@@ -1,15 +1,11 @@
 .body-spinner {
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: #ffffff;
+  position: relative;
+  width: 100%;
+  min-height: calc(100vh - 200px);
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 20px;
-  z-index: 9999;
-  flex-direction: row;
+  padding: 50px 20px;
 }
 
 .body-spinner .spinner-body {
@@ -25,10 +21,6 @@
   to {
     transform: rotate(360deg);
   }
-}
-
-[data-theme="dark"] .body-spinner {
-  background: #0d1117;
 }
 
 [data-theme="dark"] .spinner-body {

--- a/frontend/src/hooks/profile/useProfile.ts
+++ b/frontend/src/hooks/profile/useProfile.ts
@@ -21,6 +21,7 @@ interface ChangePasswordForm {
 export default function useProfile() {
   const { loading, error, request } = useApiRequester();
   const [userData, setUserData] = useState<User | null>(null);
+  const [isInitialized, setIsInitialized] = useState(false);
 
   const getLoggedInUserData = async () => {
     try {
@@ -28,6 +29,8 @@ export default function useProfile() {
       setUserData(result);
     } catch (error) {
       console.error("Error fetching user profile:", error);
+    } finally {
+      setIsInitialized(true);
     }
   };
 
@@ -96,6 +99,7 @@ export default function useProfile() {
 
   return {
     loading,
+    isInitialized,
     userData,
     error,
     getLoggedInUserData,

--- a/frontend/src/hooks/utils/useProfileUtils.ts
+++ b/frontend/src/hooks/utils/useProfileUtils.ts
@@ -11,6 +11,7 @@ export default function useUserProfile() {
   return {
     // Profile
     loading: profileMethods.loading,
+    isInitialized: profileMethods.isInitialized,
     userData: profileMethods.userData,
     error: profileMethods.error,
     getLoggedInUserData: profileMethods.getLoggedInUserData,


### PR DESCRIPTION
Add Open Graph/Twitter meta tags and canonical link to index.html for better SEO/share previews. Rename hooks/utils/useProfile.ts to useProfileUtils.ts and update imports across components. Expose a new isInitialized flag from the profile hook and use it in Profile to avoid rendering before initialization. Simplify Spinner markup, add ARIA label, and adjust bodySpinner.css layout so the spinner no longer covers the full viewport and has improved spacing.