### PR TITLE
Use favicon as OG/Twitter/social image

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,14 +14,14 @@
   <meta name="description" content="Discover your next career move with our job board. Browse thousands of job listings and find the perfect fit." />
   <meta property="og:title" content="Job Board - Find Your Next Opportunity" />
   <meta property="og:description" content="Discover your next career move with our job board. Browse thousands of job listings and find the perfect fit." />
-  <meta property="og:image" content="https://job-board-three-omega.vercel.app/og-default.svg" />
+  <meta property="og:image" content="https://job-board-three-omega.vercel.app/assets/favicons/web-app-manifest-512x512.png" />
   <meta property="og:url" content="https://job-board-three-omega.vercel.app/" />
   <meta property="og:site_name" content="Job Board" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Job Board - Find Your Next Opportunity" />
   <meta name="twitter:description" content="Discover your next career move with our job board. Browse thousands of job listings and find the perfect fit." />
-  <meta name="twitter:image" content="https://job-board-three-omega.vercel.app/og-default.svg" />
+  <meta name="twitter:image" content="https://job-board-three-omega.vercel.app/assets/favicons/web-app-manifest-512x512.png" />
   <link rel="canonical" href="https://job-board-three-omega.vercel.app/" />
     <title>Job Board - Find Your Next Opportunity</title>
   </head>

--- a/frontend/src/seo/seo.ts
+++ b/frontend/src/seo/seo.ts
@@ -25,7 +25,7 @@ export const generateSeoConfig = (pageKey: string, dynamicValue?: string): SeoCo
   return {
     title: "Job Board",
     description: "Find your next job opportunity.",
-    image: "https://job-board-three-omega.vercel.app/og-default.svg",
+    image: "https://job-board-three-omega.vercel.app/assets/favicons/web-app-manifest-512x512.png",
     url: "https://job-board-three-omega.vercel.app/",
     siteName: "Job Board",
     type: "website",
@@ -37,7 +37,7 @@ export const seoConfig: Record<string, SeoConfig> = {
   home: {
     title: "Job Board - Find Your Next Opportunity",    
     description: "Discover your next career move with our job board. Browse thousands of job listings, find the perfect fit, and take the next step in your professional journey.",
-    image: "https://job-board-three-omega.vercel.app/og-default.svg",
+    image: "https://job-board-three-omega.vercel.app/assets/favicons/web-app-manifest-512x512.png",
     url: "https://job-board-three-omega.vercel.app/",
     siteName: "Job Board",
     type: "website",


### PR DESCRIPTION
Replace references to og-default.svg with the 512x512 app favicon (assets/favicons/web-app-manifest-512x512.png) to standardize social preview images. Updated meta tags in frontend/index.html (og:image, twitter:image) and the default/home image values in frontend/src/seo/seo.ts.