### PR TITLE
Add Open Graph image metadata (type/size/secure)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,6 +15,10 @@
   <meta property="og:title" content="Job Board - Find Your Next Opportunity" />
   <meta property="og:description" content="Discover your next career move with our job board. Browse thousands of job listings and find the perfect fit." />
   <meta property="og:image" content="https://job-board-three-omega.vercel.app/og-card-v2.png" />
+  <meta property="og:image:secure_url" content="https://job-board-three-omega.vercel.app/og-card-v2.png" />
+  <meta property="og:image:type" content="image/png" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
   <meta property="og:url" content="https://job-board-three-omega.vercel.app/" />
   <meta property="og:site_name" content="Job Board" />
   <meta property="og:type" content="website" />

--- a/frontend/src/seo/MetaDataTags.tsx
+++ b/frontend/src/seo/MetaDataTags.tsx
@@ -14,6 +14,10 @@ export default function SeoHead({ seo }: SeoHeadProps) {
       <meta property="og:title" content={seo.title} />
       <meta property="og:description" content={seo.description} />
       {seo.image && <meta property="og:image" content={seo.image} />}
+      {seo.image && <meta property="og:image:secure_url" content={seo.image} />}
+      {seo.image && <meta property="og:image:type" content="image/png" />}
+      {seo.image && <meta property="og:image:width" content="1200" />}
+      {seo.image && <meta property="og:image:height" content="630" />}
       {seo.url && <meta property="og:url" content={seo.url} />}
       {seo.siteName && <meta property="og:site_name" content={seo.siteName} />}
       {seo.type && <meta property="og:type" content={seo.type} />}


### PR DESCRIPTION
Include additional Open Graph image tags to improve social previews. Adds og:image:secure_url (same image URL), og:image:type (image/png), og:image:width (1200) and og:image:height (630) to frontend/index.html and mirrors these tags in MetaDataTags.tsx (conditionally rendered when seo.image is present) so platforms receive explicit MIME and dimension info.